### PR TITLE
Remove dependency on hh5 in model run 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,9 +49,8 @@ userscripts:
 modules:
     use:
         - /g/data/vk83/modules
-        - /g/data/hh5/public/modules
     load:
         - access-om3/2024.09.0
-        - conda/analysis3-24.01
+        - nco/5.0.5
 
 payu_minimum_version: 1.1.4


### PR DESCRIPTION
per https://github.com/COSIMA/access-om3/issues/229

Note that the archive script starts a seperate PBS job which uses hh5